### PR TITLE
Refactor Ansible tasks to use consistent variable naming for temporar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ This Ansible role provides a standardized approach to deploy configuration files
 
 ### Target Server Requirements
 - Git package installed
-- Tree package installed (for display output)
 - Sudo privileges for the Ansible user (if modifying system files)
 
 ## Installation
@@ -75,7 +74,7 @@ pip install molecule molecule-docker ansible-lint yamllint
 Install required packages on target servers:
 ```bash
 # On Rocky Linux/RHEL 9
-sudo dnf install git tree
+sudo dnf install git
 ```
 
 ## Quick Start
@@ -254,7 +253,7 @@ staging:
 
 ### Task Overview
 
-1. **main.yml**: Entry point that displays tree output and includes server tasks
+1. **main.yml**: Entry point that includes server tasks
 2. **server.yml**: Handles server-specific configuration deployment
 3. **config.yml**: Manages individual configuration file deployments
 
@@ -284,7 +283,7 @@ molecule verify
 ### Test Environment
 
 The testing setup includes:
-- **prepare.yml**: Installs dependencies (git, tree) and configures git safe directories
+- **prepare.yml**: Installs dependencies (git) and configures git safe directories
 - **converge.yml**: Applies the role to test instances
 - **verify.yml**: Validates the deployment results
 - **Dockerfile.j2**: Defines the test container environment
@@ -436,7 +435,6 @@ This role has no external Ansible role dependencies, making it lightweight and e
 
 ### System Dependencies
 - **git**: Required for repository operations
-- **tree**: Used for directory structure display (optional)
 - **sudo**: Required if deploying files requiring elevated privileges
 
 ### Python Dependencies
@@ -498,10 +496,10 @@ TASK [ns.hcvdeployfiles : Clone git repository] *** FATAL: [server01]: FAILED! =
 **Solution**: The prepare phase installs required packages. For manual installation:
 ```bash
 # Rocky Linux/RHEL 9
-sudo dnf install git tree
+sudo dnf install git
 
 # Ubuntu/Debian
-sudo apt-get install git tree
+sudo apt-get install git
 ```
 
 #### Repository Access Issues

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,48 +5,51 @@
   register: __temp_dir_config
   changed_when: false
 
-- name: Clone git repository
-  ansible.builtin.git:
-    repo: "{{ __loop_server.repo }}"
-    version: "{{ __loop_server.version }}"
-    dest: "{{ __temp_dir_config.path }}"
-    force: true
-  changed_when: false
+- name: Manage config files
+  block:
+    - name: Clone git repository
+      ansible.builtin.git:
+        repo: "{{ __loop_server.repo }}"
+        version: "{{ __loop_server.version }}"
+        dest: "{{ __temp_dir_config.path }}"
+        force: true
+      changed_when: false
 
-- name: Use config file from git as variable
-  ansible.builtin.slurp:
-    src: "{{ __temp_dir_config.path }}/.config.yml"
-  register: __temp_var
+    - name: Use config file from git as variable
+      ansible.builtin.slurp:
+        src: "{{ __temp_dir_config.path }}/.config.yml"
+      register: __temp_var
 
-- name: Set variable from config file
-  ansible.builtin.set_fact:
-    __config: "{{ __temp_var.content | b64decode | from_yaml }}"
+    - name: Set variable from config file
+      ansible.builtin.set_fact:
+        __config: "{{ __temp_var.content | b64decode | from_yaml }}"
 
-- name: Create required directories
-  ansible.builtin.file:
-    path: "/{{ __loop_dir.name }}"
-    state: directory
-    mode: "{{ __loop_dir.mode | default(omit) }}"
-    owner: "{{ __loop_dir.owner | default(omit) }}"
-    group: "{{ __loop_dir.group | default(omit) }}"
-  loop: "{{ __config.directories }}"
-  loop_control:
-    loop_var: __loop_dir
+    - name: Create required directories
+      ansible.builtin.file:
+        path: "/{{ __loop_dir.name }}"
+        state: directory
+        mode: "{{ __loop_dir.mode | default(omit) }}"
+        owner: "{{ __loop_dir.owner | default(omit) }}"
+        group: "{{ __loop_dir.group | default(omit) }}"
+      loop: "{{ __config.directories }}"
+      loop_control:
+        loop_var: __loop_dir
 
-- name: Deploy files
-  ansible.builtin.copy:
-    src: "{{ __temp_dir_config.path }}/{{ __loop_file.file }}"
-    dest: "/{{ __loop_file.file }}"
-    mode: "{{ __loop_file.mode | default(omit) }}"
-    owner: "{{ __loop_file.owner | default(omit) }}"
-    group: "{{ __loop_file.group | default(omit) }}"
-    remote_src: true
-  loop: "{{ __config.files }}"
-  loop_control:
-    loop_var: __loop_file
+    - name: Deploy files
+      ansible.builtin.copy:
+        src: "{{ __temp_dir_config.path }}/{{ __loop_file.file }}"
+        dest: "/{{ __loop_file.file }}"
+        mode: "{{ __loop_file.mode | default(omit) }}"
+        owner: "{{ __loop_file.owner | default(omit) }}"
+        group: "{{ __loop_file.group | default(omit) }}"
+        remote_src: true
+      loop: "{{ __config.files }}"
+      loop_control:
+        loop_var: __loop_file
 
-- name: Remove temporary directory
-  ansible.builtin.file:
-    path: "{{ __temp_dir_config.path }}"
-    state: absent
-  changed_when: false
+  always:
+    - name: Remove temporary directory
+      ansible.builtin.file:
+        path: "{{ __temp_dir_config.path }}"
+        state: absent
+      changed_when: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,7 +24,7 @@
 
 - name: Create required directories
   ansible.builtin.file:
-    dest: "/{{ __loop_dir.name }}"
+    path: "/{{ __loop_dir.name }}"
     state: directory
     mode: "{{ __loop_dir.mode | default(omit) }}"
     owner: "{{ __loop_dir.owner | default(omit) }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,20 +2,20 @@
 - name: Create temporary directory
   ansible.builtin.tempfile:
     state: directory
-  register: temp_dir
+  register: __temp_dir_config
   changed_when: false
 
 - name: Clone git repository
   ansible.builtin.git:
     repo: "{{ __loop_server.repo }}"
     version: "{{ __loop_server.version }}"
-    dest: "{{ temp_dir.path }}"
+    dest: "{{ __temp_dir_config.path }}"
     force: true
   changed_when: false
 
 - name: Use config file from git as variable
   ansible.builtin.slurp:
-    src: "{{ temp_dir.path }}/.config.yml"
+    src: "{{ __temp_dir_config.path }}/.config.yml"
   register: __temp_var
 
 - name: Set variable from config file
@@ -24,29 +24,29 @@
 
 - name: Create required directories
   ansible.builtin.file:
-    dest: "/{{ __loop_config.name }}"
+    dest: "/{{ __loop_dir.name }}"
     state: directory
-    mode: "{{ __loop_config.mode | default(omit) }}"
-    owner: "{{ __loop_config.owner | default(omit) }}"
-    group: "{{ __loop_config.group | default(omit) }}"
+    mode: "{{ __loop_dir.mode | default(omit) }}"
+    owner: "{{ __loop_dir.owner | default(omit) }}"
+    group: "{{ __loop_dir.group | default(omit) }}"
   loop: "{{ __config.directories }}"
   loop_control:
-    loop_var: __loop_config
+    loop_var: __loop_dir
 
 - name: Deploy files
   ansible.builtin.copy:
-    src: "{{ temp_dir.path }}/{{ __loop_config.file }}"
-    dest: "/{{ __loop_config.file }}"
-    mode: "{{ __loop_config.mode | default(omit) }}"
-    owner: "{{ __loop_config.owner | default(omit) }}"
-    group: "{{ __loop_config.group | default(omit) }}"
+    src: "{{ __temp_dir_config.path }}/{{ __loop_file.file }}"
+    dest: "/{{ __loop_file.file }}"
+    mode: "{{ __loop_file.mode | default(omit) }}"
+    owner: "{{ __loop_file.owner | default(omit) }}"
+    group: "{{ __loop_file.group | default(omit) }}"
     remote_src: true
   loop: "{{ __config.files }}"
   loop_control:
-    loop_var: __loop_config
+    loop_var: __loop_file
 
 - name: Remove temporary directory
   ansible.builtin.file:
-    name: "{{ temp_dir.path }}"
+    name: "{{ __temp_dir_config.path }}"
     state: absent
   changed_when: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -47,6 +47,6 @@
 
 - name: Remove temporary directory
   ansible.builtin.file:
-    name: "{{ __temp_dir_config.path }}"
+    path: "{{ __temp_dir_config.path }}"
     state: absent
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,3 @@
 ---
-- name: Show tree command output
-  ansible.builtin.debug:
-    var: tree_output.stdout_lines
-
 - name: Download configs for a server
   ansible.builtin.include_tasks: server.yml

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -2,20 +2,20 @@
 - name: Create temporary directory
   ansible.builtin.tempfile:
     state: directory
-  register: temp_dir
+  register: __temp_dir_server
   changed_when: false
 
 - name: Clone git repository
   ansible.builtin.git:
     repo: "{{ git_repo }}"
-    dest: "{{ temp_dir.path }}"
+    dest: "{{ __temp_dir_server.path }}"
     version: "{{ git_version }}"
     force: true
   changed_when: false
 
 - name: Use config file from git as variable
   ansible.builtin.slurp:
-    src: "{{ temp_dir.path }}/{{ ansible_hostname }}.yaml"
+    src: "{{ __temp_dir_server.path }}/{{ ansible_facts['hostname'] }}.yaml"
   register: __temp_var
 
 - name: Set variable from config file
@@ -33,3 +33,9 @@
   loop: "{{ __server }}"
   loop_control:
     loop_var: __loop_server
+
+- name: Remove temporary directory
+  ansible.builtin.file:
+    name: "{{ __temp_dir_server.path }}"
+    state: absent
+  changed_when: false

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -31,7 +31,7 @@
     - name: Start configuration tasks
       ansible.builtin.include_tasks: config.yml
       vars:
-        __loop_config: "{{ item }}"
+        __loop_config: "{{ __loop_server }}"
       loop: "{{ __server }}"
       loop_control:
         loop_var: __loop_server

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -5,37 +5,40 @@
   register: __temp_dir_server
   changed_when: false
 
-- name: Clone git repository
-  ansible.builtin.git:
-    repo: "{{ git_repo }}"
-    dest: "{{ __temp_dir_server.path }}"
-    version: "{{ git_version }}"
-    force: true
-  changed_when: false
+- name: Manage server config
+  block:
+    - name: Clone git repository
+      ansible.builtin.git:
+        repo: "{{ git_repo }}"
+        dest: "{{ __temp_dir_server.path }}"
+        version: "{{ git_version }}"
+        force: true
+      changed_when: false
 
-- name: Use config file from git as variable
-  ansible.builtin.slurp:
-    src: "{{ __temp_dir_server.path }}/{{ ansible_facts['hostname'] }}.yaml"
-  register: __temp_var
+    - name: Use config file from git as variable
+      ansible.builtin.slurp:
+        src: "{{ __temp_dir_server.path }}/{{ ansible_facts['hostname'] }}.yaml"
+      register: __temp_var
 
-- name: Set variable from config file
-  ansible.builtin.set_fact:
-    __server: "{{ __temp_var.content | b64decode | from_yaml }}"
+    - name: Set variable from config file
+      ansible.builtin.set_fact:
+        __server: "{{ __temp_var.content | b64decode | from_yaml }}"
 
-- name: Debug config
-  ansible.builtin.debug:
-    var: __server
+    - name: Debug config
+      ansible.builtin.debug:
+        var: __server
 
-- name: Start configuration tasks
-  ansible.builtin.include_tasks: config.yml
-  vars:
-    __loop_config: "{{ item }}"
-  loop: "{{ __server }}"
-  loop_control:
-    loop_var: __loop_server
+    - name: Start configuration tasks
+      ansible.builtin.include_tasks: config.yml
+      vars:
+        __loop_config: "{{ item }}"
+      loop: "{{ __server }}"
+      loop_control:
+        loop_var: __loop_server
 
-- name: Remove temporary directory
-  ansible.builtin.file:
-    path: "{{ __temp_dir_server.path }}"
-    state: absent
-  changed_when: false
+  always:
+    - name: Remove temporary directory
+      ansible.builtin.file:
+        path: "{{ __temp_dir_server.path }}"
+        state: absent
+      changed_when: false

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -36,6 +36,6 @@
 
 - name: Remove temporary directory
   ansible.builtin.file:
-    name: "{{ __temp_dir_server.path }}"
+    path: "{{ __temp_dir_server.path }}"
     state: absent
   changed_when: false


### PR DESCRIPTION
- [x] Wrap tasks in `config.yml` in a `block` with `always` cleanup section
- [x] Wrap tasks in `server.yml` in a `block` with `always` cleanup section
- [x] Update README to remove stale `tree` package/output references
- [x] Run validation